### PR TITLE
htmlwidget reporting updates

### DIFF
--- a/inst/config/aeExplorer.yaml
+++ b/inst/config/aeExplorer.yaml
@@ -2,6 +2,7 @@ label: Adverse Event Explorer
 type: htmlwidget
 domain: multiple
 package: safetyCharts  
+export: true
 workflow:
   init: init_aeExplorer
   widget: aeExplorer

--- a/inst/config/aeTimelines.yaml
+++ b/inst/config/aeTimelines.yaml
@@ -1,6 +1,7 @@
 label: Safety Timelines
 type: htmlwidget
 domain: aes
-package: safetyCharts  
+package: safetyCharts
+export: false  
 workflow:
   widget: aeTimelines

--- a/inst/config/hepexplorer.yaml
+++ b/inst/config/hepexplorer.yaml
@@ -2,5 +2,6 @@ label: Hepatic Safety Explorer
 type: htmlwidget
 domain: labs
 package: safetyCharts  
+export: true
 workflow:
   widget: hepexplorer

--- a/inst/config/labdist.yaml
+++ b/inst/config/labdist.yaml
@@ -1,6 +1,7 @@
 label: Labs Distribution (custom shiny module)
 type: module
 domain: labs
+export: true
 workflow:
   ui: labdist_ui
   server: labdist_server

--- a/inst/config/paneledOutlierExplorer.yaml
+++ b/inst/config/paneledOutlierExplorer.yaml
@@ -2,6 +2,7 @@ label: Paneled Outlier Explorer (widget)
 type: htmlwidget
 domain: labs
 package: safetyCharts
+export: true
 workflow:
   init: init_paneledOutlierExplorer
   widget: paneledOutlierExplorer

--- a/inst/config/safetyDeltaDelta.yaml
+++ b/inst/config/safetyDeltaDelta.yaml
@@ -2,5 +2,6 @@ label: Delta-Delta
 type: htmlwidget
 domain: labs
 package: safetyCharts
+export: true
 workflow:
   widget: safetyDeltaDelta

--- a/inst/config/safetyHistogram.yaml
+++ b/inst/config/safetyHistogram.yaml
@@ -2,5 +2,6 @@ label: Histogram
 type: htmlwidget
 domain: labs
 package: safetyCharts
+export: true
 workflow:
   widget: safetyHistogram

--- a/inst/config/safetyOutlierExplorer.yaml
+++ b/inst/config/safetyOutlierExplorer.yaml
@@ -2,6 +2,7 @@ label: Outlier Explorer (widget)
 type: htmlwidget
 domain: labs
 package: safetyCharts
+export: true
 workflow:
   init: init_safetyOutlierExplorer
   widget: safetyOutlierExplorer

--- a/inst/config/safetyOutlierExplorerModule.yaml
+++ b/inst/config/safetyOutlierExplorerModule.yaml
@@ -2,6 +2,7 @@ label: Outlier Explorer (module)
 type: module
 domain: labs
 package: safetyCharts
+export: true
 workflow:
   ui: safetyOutlierExplorer_ui
   server: safetyOutlierExplorer_server

--- a/inst/config/safetyOutlierExplorerModule.yaml
+++ b/inst/config/safetyOutlierExplorerModule.yaml
@@ -2,7 +2,7 @@ label: Outlier Explorer (module)
 type: module
 domain: labs
 package: safetyCharts
-export: true
+export: false
 workflow:
   ui: safetyOutlierExplorer_ui
   server: safetyOutlierExplorer_server

--- a/inst/config/safetyOutlierExplorerStatic.yaml
+++ b/inst/config/safetyOutlierExplorerStatic.yaml
@@ -2,5 +2,6 @@ label: Outlier Explorer (Static)
 type: plot
 domain: labs
 package: safetyCharts
+export: true
 workflow:
   main: safety_outlier_explorer

--- a/inst/config/safetyResultsOverTime.yaml
+++ b/inst/config/safetyResultsOverTime.yaml
@@ -2,6 +2,7 @@ label: Results Over Time
 type: htmlwidget
 domain: labs
 package: safetyCharts
+export: true
 workflow:
   init: init_safetyResultsOverTime
   widget: safetyResultsOverTime

--- a/inst/config/safetyResultsOverTimeStatic.yaml
+++ b/inst/config/safetyResultsOverTimeStatic.yaml
@@ -2,5 +2,6 @@ label: Results Over Time (Static)
 type: plot
 domain: labs
 package: safetyCharts
+export: true
 workflow:
   main: safety_results_over_time

--- a/inst/config/safetyShiftPlot.yaml
+++ b/inst/config/safetyShiftPlot.yaml
@@ -2,6 +2,7 @@ label: Shift Plot
 type: htmlwidget
 domain: labs
 package: safetyCharts
+export: true
 workflow:
   init: init_safetyShiftPlot
   widget: safetyShiftPlot

--- a/inst/config/tendril.yaml
+++ b/inst/config/tendril.yaml
@@ -2,5 +2,6 @@ label: Tendril Plot {Tendril}
 type: plot
 domain: multiple
 package: safetyCharts
+export: true
 workflow:
   main: tendril_chart

--- a/inst/config/tplyr_demog.yaml
+++ b/inst/config/tplyr_demog.yaml
@@ -2,5 +2,6 @@ label: Demographics Table {Tplyr} + {DT}
 type: table
 domain: dm
 package: safetyCharts
+export: true
 workflow:
   main: tplyr_demog_chart

--- a/inst/config/tplyr_shift.yaml
+++ b/inst/config/tplyr_shift.yaml
@@ -2,5 +2,6 @@ label: Shift Table {Tplyr} + {kable}
 type: html
 domain: multiple
 pacakage: Tplyr
+export: false
 workflow:
   main: tplyr_shift_chart

--- a/inst/htmlwidgets/aeTimelines.js
+++ b/inst/htmlwidgets/aeTimelines.js
@@ -6,19 +6,16 @@ HTMLWidgets.widget({
 
   factory: function(el, width, height) {
 
-   return {
+  return {
 
       renderValue: function(x) {
 
       el.innerHTML = "";
-        
-        
       x.data = HTMLWidgets.dataframeToD3(x.data);
-      
       console.log(x.settings);
-      
-       
-       aeTimelines(el, x.settings).init(x.data);
+  
+      let wrapID = "#"+d3.select(el).property("id");
+      aeTimelines(wrapID, x.settings).init(x.data);
 
       },
 

--- a/inst/htmlwidgets/hepExplorer.js
+++ b/inst/htmlwidgets/hepExplorer.js
@@ -6,15 +6,12 @@ HTMLWidgets.widget({
 
     return {
       renderValue: function(rSettings) {
-        console.log("widget started ...")
-        console.log(el)
         console.log(rSettings)
-        //console.log(rSettings)
-        //el.innerHTML = "<div class='.hepexplorer-wrap'></div>";
         el.innerHTML=""
         let settings = rSettings.settings;
         let data = HTMLWidgets.dataframeToD3(rSettings.data);
-        var chart = hepexplorer("#"+rSettings.ns, settings)
+        let wrapID = rSettings.ns ? "#"+rSettings.ns : "#"+d3.select(el).property("id");
+        var chart = hepexplorer(wrapID, settings)
         chart.init(data);
       },
       resize: function(width, height) {

--- a/inst/htmlwidgets/safetyDeltaDelta.js
+++ b/inst/htmlwidgets/safetyDeltaDelta.js
@@ -14,7 +14,8 @@ HTMLWidgets.widget({
         el.innerHTML=""
         let settings = rSettings.settings;
         let data = HTMLWidgets.dataframeToD3(rSettings.data);
-        var chart = safetyDeltaDelta("#"+rSettings.ns, settings)
+        let wrapID = rSettings.ns ? "#"+rSettings.ns : "#"+d3.select(el).property("id");
+        var chart = safetyDeltaDelta(wrapID, settings)
         chart.init(data);
       },
       resize: function(width, height) {

--- a/inst/htmlwidgets/safetyShiftPlot.js
+++ b/inst/htmlwidgets/safetyShiftPlot.js
@@ -17,8 +17,9 @@ HTMLWidgets.widget({
         x.data = HTMLWidgets.dataframeToD3(x.data);
         
         console.log(x.settings);
+        let wrapID = x.ns ? "#"+x.ns : "#"+d3.select(el).property("id");
 
-        safetyShiftPlot("#" + x.ns, x.settings).init(x.data);
+        safetyShiftPlot(wrapID, x.settings).init(x.data);
 
       },
 


### PR DESCRIPTION
# Summary

This PR along with https://github.com/SafetyGraphics/safetyGraphics/pull/526 fixes issues in htmlwidget reporting. Including those in #49. 

Now all standard renderers expect for AE Timelines should be working well in safetyGraphics reports. See #51 for a summary of the AE Timelines issues. 

# Test Notes. 

Same as  https://github.com/SafetyGraphics/safetyGraphics/pull/526 - Make sure all exported charts work as expected using the following branches: 

```
devtools::install_github("safetyGraphics/safetyCharts", ref="fix-49")
library(safetyCharts)
devtools::install_github("safetyGraphics/safetyGraphics", ref="reports-updates")
library(safetyGraphics)
safetyGraphics::safetyGraphicsApp()
```