### PR TITLE
fix: replaces geom_path for geom_line in safety outlier explorer

### DIFF
--- a/R/safety_outlier_explorer.R
+++ b/R/safety_outlier_explorer.R
@@ -47,7 +47,7 @@ safety_outlier_explorer <- function(data, settings) {
     }
 
     p <- ggplot(data = sub, params) +
-        geom_path(color = "black", alpha = 0.15) +
+        geom_line(color = "black", alpha = 0.15) +
         labs(x = "Study Day", y = "Lab Value", title = "Lab Overview", subtitle = "") +
         facet_grid(
             rows = as.name(settings$measure_col),


### PR DESCRIPTION
According to ggplot doc:

> geom_path() connects the observations in the order in which they appear in the data. geom_line() connects them in order of the variable on the x axis. 

For this plot is more intuitive if lines are plotted sorted according to x values and not to data appearance.

Fix: #85