### PR TITLE
fix #93

### DIFF
--- a/inst/config/QTOutlierExplorerModule.yaml
+++ b/inst/config/QTOutlierExplorerModule.yaml
@@ -4,7 +4,7 @@ name: qTexplorer
 type: module
 package: safetyCharts
 export: true
-order: 37
+order: -37
 domain: 
   - ecg
 workflow:

--- a/inst/config/QTpaneledOutlierExplorer.yaml
+++ b/inst/config/QTpaneledOutlierExplorer.yaml
@@ -5,7 +5,7 @@ domain:
   - ecg
 package: safetyCharts
 export: true
-order: 32
+order: -32
 workflow:
   init: init_paneledOutlierExplorer
   widget: paneledOutlierExplorer

--- a/inst/config/QTsafetyDeltaDelta.yaml
+++ b/inst/config/QTsafetyDeltaDelta.yaml
@@ -3,7 +3,7 @@ label: QT Delta-Delta
 type: htmlwidget
 package: safetyCharts
 export: true
-order: 36
+order: -36
 domain: 
   - ecg
 workflow:

--- a/inst/config/QTsafetyHistogram.yaml
+++ b/inst/config/QTsafetyHistogram.yaml
@@ -5,7 +5,7 @@ package: safetyCharts
 domain: 
   - ecg
 export: true
-order: 33
+order: -33
 workflow:
   widget: safetyHistogram
 links:

--- a/inst/config/QTsafetyOutlierExplorer.yaml
+++ b/inst/config/QTsafetyOutlierExplorer.yaml
@@ -3,7 +3,7 @@ label: QT Outlier Explorer
 type: htmlwidget
 package: safetyCharts
 export: true
-order: 31
+order: -31
 domain: 
   - ecg
 workflow:

--- a/inst/config/QTsafetyResultsOverTime.yaml
+++ b/inst/config/QTsafetyResultsOverTime.yaml
@@ -3,7 +3,7 @@ label: QT Results Over Time
 type: htmlwidget
 package: safetyCharts
 export: true
-order: 34
+order: -34
 domain: 
   - ecg
 workflow:

--- a/inst/config/QTsafetyShiftPlot.yaml
+++ b/inst/config/QTsafetyShiftPlot.yaml
@@ -3,7 +3,7 @@ label: QT Shift Plot
 type: htmlwidget
 package: safetyCharts
 export: true
-order: 35
+order: -35
 domain: 
   - ecg
 workflow:


### PR DESCRIPTION
# Summary 

Remove ecg charts from default for now 

# Test notes

Charts should appear unselected by default when running `safetyGraphicsInit()`