### PR TITLE
fix custom init for ae explorer. fix #39

### DIFF
--- a/R/init_aeExplorer.R
+++ b/R/init_aeExplorer.R
@@ -9,34 +9,33 @@
 
 
 init_aeExplorer <- function(data, settings) {
-
     # Merge treatment with adverse events.
     dm_sub <- data$dm %>% select(settings[["dm"]][["id_col"]], settings[["dm"]][["treatment_col"]])
     anly <- dm_sub %>% left_join(data$aes) # left join to keep all rows in dm (even if there were no AEs)
 
-    settings <- c(settings$aes, settings$labs)
+    ae_settings <- list()
 
-    settings$variables <- list(
-        major = settings[["bodsys_col"]],
-        minor = settings[["term_col"]],
-        group = settings[["trt_col"]],
-        id = paste0(settings[["id_col"]]),
+    ae_settings$variables <- list(
+        major = settings[['aes']][["bodsys_col"]],
+        minor = settings[['aes']][["term_col"]],
+        group = settings[["dm"]][["treatment_col"]],
+        id = settings[["dm"]][["id_col"]],
         filters = list(),
         details = list()
     )
 
-    settings$variableOptions <- list(
+    ae_settings$variableOptions <- list(
         group = c(
-            settings[["treatment_values--group1"]],
-            settings[["treatment_values--group2"]]
+            settings[['dm']][["treatment_values--group1"]],
+            settings[['dm']][["treatment_values--group2"]]
         )
     )
 
-    settings$defaults <- list(
+    ae_settings$defaults <- list(
         placeholderFlag = list(
-            valueCol = settings[["bodsys_col"]],
+            valueCol = settings[['aes']][["bodsys_col"]],
             values = c("", NA, NULL)
         )
     )
-    return(list(data = anly, settings = settings))
+    return(list(data = anly, settings = ae_settings))
 }


### PR DESCRIPTION
# Overview

Update custom mapping in `init_safetyExplorer`. Widget couldn't be customized with previous version. 

Fix #39 

# Test notes

Install this branch and then run safetyGraphics using branch `fix-637`. Confirm that updating the mapping for Treatment (under dm), System Organ Class and  Preferred Term result in updates in the AE Explorer widget. Example shown in screenshot below. 

<img width="1054" alt="image" src="https://user-images.githubusercontent.com/3680095/159161116-d53f849f-55ad-4398-9996-72c8bb00eb70.png">

<img width="1009" alt="image" src="https://user-images.githubusercontent.com/3680095/159161138-b2b983cf-f693-4a75-b867-00ca1075458c.png">
